### PR TITLE
Patch JSX-A11Y Linter

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -15,5 +15,8 @@
   "env": {
     "mocha": true,
     "jest": true
-  }
+  },
+  "plugins": [
+    "jsx-a11y"
+  ]
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,5 +26,9 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "eslint": "^4.19.1"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glossier/eslint-config",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "description": "How we write JavaScript at Glossier",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config/test/index.js
+++ b/packages/eslint-config/test/index.js
@@ -18,7 +18,9 @@ const lint = text => {
 }
 
 test('disallow line longer than 100 characters', t => {
-  const result = lint("const books = ['JavaScript: The Good Parts', 'ES6 & Beyond', 'Eloquent JavaScript A Modern Introduction to Programming']")
+  const result = lint(
+    "const books = ['JavaScript: The Good Parts', 'ES6 & Beyond', 'Eloquent JavaScript A Modern Introduction to Programming']"
+  )
   t.is(result.errorCount, 1)
   t.is(result.messages[0].ruleId, 'max-len')
 })
@@ -45,4 +47,10 @@ test('focused test are not allowed', t => {
   const result = lint('test.only(() => { /**/ })')
   t.is(result.errorCount, 1)
   t.is(result.messages[0].ruleId, 'jest/no-focused-tests')
+})
+
+test('disallows a11y violations', t => {
+  const result = lint("const image = <img src='image.png' />")
+  t.is(result.errorCount, 1)
+  t.is(result.messages[0].ruleId, 'jsx-a11y/alt-text')
 })


### PR DESCRIPTION
This PR adds `jsx-a11y` to the `eslintrc.json` and adds specs for the linter.

This PR also adjusts the prettier configs for this project to not add semicolons and use single quotes.

