### PR TITLE
JSX-A11Y label-has-for Configuration

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -10,7 +10,17 @@
   "rules": {
     "max-len": ["error", 100],
     "prefer-const": "error",
-    "no-var": "error"
+    "no-var": "error",
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "required": {
+          "every": [
+            "id"
+          ]
+        }
+      }
+    ]
   },
   "env": {
     "mocha": true,

--- a/packages/eslint-config/test/index.js
+++ b/packages/eslint-config/test/index.js
@@ -54,3 +54,11 @@ test('disallows a11y violations', t => {
   t.is(result.errorCount, 1)
   t.is(result.messages[0].ruleId, 'jsx-a11y/alt-text')
 })
+
+test('makes exception for jsx-a11y label-has-for rule', t => {
+  const result = lint(
+    `const template = <div><label htmlFor='checkbox'>label</label>
+  <input id='checkbox' type='checkbox' /></div>`
+  )
+  t.is(result.errorCount, 0)
+})


### PR DESCRIPTION
This PR proposes to make an adjustment to the `label-has-for` rule under the`jsx-a11y` linter. 

Currently, the configuration of `eslint-plugin-jsx-a11y` will raise an error if an `input` is not wrapped with a `label` and will not recognize an `id` matched with its corresponding `htmlFor` as a valid and semantic form input.

This will allow the following to pass:

```
<label htmlFor="newsletter">Label</label>
<input type="email" id="newsletter" />
```

Although [`label-has-for` is deemed deprecated](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md), I still find that it's valid for us to raise issues when an `input` does not have a corresponding `label`. 



