### PR TITLE
JSX-A11Y - Allow exception for JSX autoFocus

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -20,7 +20,8 @@
           ]
         }
       }
-    ]
+    ],
+    "jsx-a11y/no-autofocus": false
   },
   "env": {
     "mocha": true,

--- a/packages/eslint-config/test/index.js
+++ b/packages/eslint-config/test/index.js
@@ -62,3 +62,8 @@ test('makes exception for jsx-a11y label-has-for rule', t => {
   )
   t.is(result.errorCount, 0)
 })
+
+test('ignores no autofocus jsx-a11y linter rule', t => {
+  const result = lint("const template = <input type='email' autoFocus />")
+  t.is(result.errorCount, 0)
+})


### PR DESCRIPTION
After discussing with design, we've decided that we'd like to make a certain exception for `autoFocus` for some cases. 

This PR disables the [`jsx-a11y/no-autofocus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md) rule for our [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y) linter.