### PR TITLE
Fix: Turning off jsx-a11y no-autoFocus linter configuration

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -21,7 +21,7 @@
         }
       }
     ],
-    "jsx-a11y/no-autofocus": false
+    "jsx-a11y/no-autofocus": 0
   },
   "env": {
     "mocha": true,


### PR DESCRIPTION
This PR proposes to create a fix for the `jsx-a11y` no-autofocus linter configuration from PR https://github.com/glossier/front-end-configs/pull/9.