### PR TITLE
Throw lint error for react/no-array-index-key.

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -21,7 +21,8 @@
         }
       }
     ],
-    "jsx-a11y/no-autofocus": 0
+    "jsx-a11y/no-autofocus": 0,
+    "react/no-array-index-key": "error"
   },
   "env": {
     "mocha": true,

--- a/packages/eslint-config/test/index.js
+++ b/packages/eslint-config/test/index.js
@@ -67,3 +67,12 @@ test('ignores no autofocus jsx-a11y linter rule', t => {
   const result = lint("const template = <input type='email' autoFocus />")
   t.is(result.errorCount, 0)
 })
+
+test('disallow map with key index', t => {
+  const result = lint(
+    `const foo = ['1', '2', '3']
+const template = foo.map((num, index) => { return <div key={index}>{num}</div> })`
+  )
+  t.is(result.errorCount, 1)
+  t.is(result.messages[0].ruleId, 'react/no-array-index-key')
+})


### PR DESCRIPTION
This PR proposes to configure our linter to throw an error for `[no-array-index-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md) to avoid this anti-pattern based on reasons described [here](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).